### PR TITLE
DCOS-57157 [Diagnostics] dcos-sdk-diagnostics tools isn't compatible with dcos-cli 0.8.x (DC/OS 1.13) if host machine has different arch than linux

### DIFF
--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -88,10 +88,11 @@ fi
 
 echo "Initializing diagnostics..."
 
-container_run "rm -rf ${CONTAINER_DCOS_CLI_DIRECTORY}
-               cp -r ${CONTAINER_DCOS_CLI_DIRECTORY_RO} ${CONTAINER_DCOS_CLI_DIRECTORY}
-               find ${CONTAINER_DCOS_CLI_DIRECTORY} \
-                 -type f \
-                 -exec sed -i -e 's|${HOST_DCOS_CLI_DIRECTORY}|${CONTAINER_DCOS_CLI_DIRECTORY}|g' {} +
+container_run "rm -rf ${CONTAINER_DCOS_CLI_DIRECTORY} && mkdir ${CONTAINER_DCOS_CLI_DIRECTORY}
+               cd ${CONTAINER_DCOS_CLI_DIRECTORY_RO}
+               find . \
+                 \( -name 'dcos.toml' -or -name 'attached' \) \
+                 -exec cp --parents \{\} ${CONTAINER_DCOS_CLI_DIRECTORY} \;
+               cd /
                PYTHONPATH=${CONTAINER_PYTHONPATH} ${CONTAINER_SCRIPT_PATH} ${*} \
                  --bundles-directory ${CONTAINER_BUNDLES_DIRECTORY}"


### PR DESCRIPTION
This PR fixes the following 3 issues:

DCOS-57157 [Diagnostics] dcos-sdk-diagnostics tools isn't compatible with dcos-cli 0.8.x (DC/OS 1.13)
COPS-5192 Property 'cluster.name' doesn't exist when trying to generate SDK bundle
DCOS-56255 [Diagnostics] The docker run command hangs for minutes before showing the script output

@mpereira please, review it.
