### PR TITLE
DCOS-58447 [Diagnostics] dcos-sdk-diagnostics tools ignores dcos-cli's DCOS_DIR env variable

### DIFF
--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -71,7 +71,7 @@ mkdir -p "${BUNDLES_DIRECTORY}"
 function container_run () {
   local -r command="${*:-}"
   docker run \
-         -it \
+         -t \
          --rm \
          -v "$(pwd)/${BUNDLES_DIRECTORY}:${CONTAINER_BUNDLES_DIRECTORY}" \
          -v "${HOST_DCOS_CLI_DIRECTORY}:${CONTAINER_DCOS_CLI_DIRECTORY_RO}":ro \

--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -11,7 +11,11 @@ readonly BUNDLES_DIRECTORY="service-diagnostic-bundles"
 readonly DOCKER_IMAGE="mesosphere/dcos-sdk-service-diagnostics:${VERSION}"
 readonly SCRIPT_NAME="create_service_diagnostics_bundle.py"
 
-readonly HOST_DCOS_CLI_DIRECTORY="${HOME}/.dcos"
+if [ -z "${DCOS_DIR}" ]; then
+  readonly HOST_DCOS_CLI_DIRECTORY="${HOME}/.dcos"
+else
+  readonly HOST_DCOS_CLI_DIRECTORY="${DCOS_DIR}"
+fi
 
 readonly CONTAINER_BUNDLES_DIRECTORY="/${BUNDLES_DIRECTORY}"
 readonly CONTAINER_DCOS_CLI_DIRECTORY_RO="/dcos-cli-directory"
@@ -70,7 +74,7 @@ function container_run () {
          -it \
          --rm \
          -v "$(pwd)/${BUNDLES_DIRECTORY}:${CONTAINER_BUNDLES_DIRECTORY}" \
-         -v "${HOME}/.dcos:${CONTAINER_DCOS_CLI_DIRECTORY_RO}":ro \
+         -v "${HOST_DCOS_CLI_DIRECTORY}:${CONTAINER_DCOS_CLI_DIRECTORY_RO}":ro \
          ${CONTAINER_DCOS_SERVICE_DIAGNOSTIC_VOLUME_MOUNT} \
          -e PYTHONPATH=${CONTAINER_DCOS_SERVICE_DIAGNOSTICS_DIRECTORY}/dcos-commons/testing:${CONTAINER_DCOS_SERVICE_DIAGNOSTICS_DIRECTORY} \
          "${DOCKER_IMAGE}" \

--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -10,12 +10,7 @@ readonly VERSION='v0.4.0'
 readonly BUNDLES_DIRECTORY="service-diagnostic-bundles"
 readonly DOCKER_IMAGE="mesosphere/dcos-sdk-service-diagnostics:${VERSION}"
 readonly SCRIPT_NAME="create_service_diagnostics_bundle.py"
-
-if [ -z "${DCOS_DIR}" ]; then
-  readonly HOST_DCOS_CLI_DIRECTORY="${HOME}/.dcos"
-else
-  readonly HOST_DCOS_CLI_DIRECTORY="${DCOS_DIR}"
-fi
+readonly HOST_DCOS_CLI_DIRECTORY="${DCOS_DIR:-${HOME}/.dcos}"
 
 readonly CONTAINER_BUNDLES_DIRECTORY="/${BUNDLES_DIRECTORY}"
 readonly CONTAINER_DCOS_CLI_DIRECTORY_RO="/dcos-cli-directory"

--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -66,7 +66,7 @@ mkdir -p "${BUNDLES_DIRECTORY}"
 function container_run () {
   local -r command="${*:-}"
   docker run \
-         -t \
+         -it \
          --rm \
          -v "$(pwd)/${BUNDLES_DIRECTORY}:${CONTAINER_BUNDLES_DIRECTORY}" \
          -v "${HOST_DCOS_CLI_DIRECTORY}:${CONTAINER_DCOS_CLI_DIRECTORY_RO}":ro \


### PR DESCRIPTION
Added checking existence DCOS_DIR env var and use it instead HOME/.dcos if it's set.