### PR TITLE
[DCOS-59150] Make Dockerfile compatible with older dockers.

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,4 @@
-ARG base_image=python:3.7.3-slim
-FROM $base_image
+FROM python:3.7.3-slim
 
 # dcos-cli and lint tooling require this to output cleanly
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8


### PR DESCRIPTION
Otherwise docker build on our jenkins fails with:
```
ERROR:docker_tools:Could not build Docker image
mesosphere/dcos-sdk-service-diagnostics:v0.5.0 from
build.33d2df31-0061-4222-8578-6551ae4d3e7f/python/Dockerfile
ERROR:docker_tools:RC: 1
STDOUT: Sending build context to Docker daemon 98.82 kB

Step 1/22 : ARG base_image=python:3.7.3-slim
STDERR: Please provide a source image with `from` prior to commit
```