### PR TITLE
[FIX] Really output supported versions.

### DIFF
--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -100,7 +100,7 @@ readonly SUPPORTED_DCOS_VERSIONS="
 2.0"
 if ! echo "${SUPPORTED_DCOS_VERSIONS}" | grep -qx "${DCOS_CLUSTER_MAJOR_MINOR_VERSION}"; then
   echo "DC/OS ${DCOS_CLUSTER_MAJOR_MINOR_VERSION}.x is not supported by this tool."
-  echo "Supported DC/OS versions: ${DCOS_CLUSTER_MAJOR_MINOR_VERSION}."
+  echo "Supported DC/OS versions: ${SUPPORTED_DCOS_VERSIONS}"
   exit 1
 fi
 


### PR DESCRIPTION
Instead of outputting the actual major/minor version.

Before:

```
$ ./create_service_diagnostics_bundle.sh
Initializing diagnostics...
Detected attached DC/OS cluster major and minor version as '2.0'
DC/OS 2.0.x is not supported by this tool.
Supported DC/OS versions: 2.0.
```

After:

```
$ ./create_service_diagnostics_bundle.sh
Initializing diagnostics...
Detected attached DC/OS cluster major and minor version as '2.0'
DC/OS 2.0.x is not supported by this tool.
Supported DC/OS versions:
1.10
1.11
1.12
1.13
1.14
```