### PR TITLE
Add initial support for DC/OS 2.1-dev

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -11,7 +11,7 @@ COPY *.py *.sh Pipfile Pipfile.lock /dcos-service-diagnostics-dist/
 
 RUN ls -la /dcos-service-diagnostics-dist
 
-ARG dcos_cli_version=1.0.1
+ARG dcos_cli_version=1.1.2
 ADD https://downloads.dcos.io/binaries/cli/linux/x86-64/$dcos_cli_version/dcos /usr/local/bin/dcos
 RUN chmod +x /usr/local/bin/dcos
 
@@ -20,13 +20,15 @@ ARG dcos111_core_cli_patch=1
 ARG dcos112_core_cli_patch=11
 ARG dcos113_core_cli_patch=6
 ARG dcos114_core_cli_patch=4
-ARG dcos2_core_cli_patch=2
+ARG dcos2_core_cli_patch=4
+ARG dcos210_core_cli_patch=latest
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.10-patch.$dcos110_core_cli_patch.zip /tmp/dcos-core-cli-1.10.zip
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.11-patch.$dcos111_core_cli_patch.zip /tmp/dcos-core-cli-1.11.zip
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.12-patch.$dcos112_core_cli_patch.zip /tmp/dcos-core-cli-1.12.zip
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.13-patch.$dcos113_core_cli_patch.zip /tmp/dcos-core-cli-1.13.zip
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.14-patch.$dcos114_core_cli_patch.zip /tmp/dcos-core-cli-1.14.zip
 ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.$dcos2_core_cli_patch.zip /tmp/dcos-core-cli-2.0.zip
+ADD https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.$dcos210_core_cli_patch.zip /tmp/dcos-core-cli-2.1.zip
 
 RUN pip install --upgrade pip &&\
         pip install pipenv && \

--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 readonly SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly DCOS_SERVICE_DIAGNOSTICS_SCRIPT_PATH="dcos-sdk-service-diagnostics/python"
 
-readonly VERSION='v0.7.0'
+readonly VERSION='v0.6.0'
 
 readonly BUNDLES_DIRECTORY="service-diagnostic-bundles"
 readonly DOCKER_IMAGE="mesosphere/dcos-sdk-service-diagnostics:${VERSION}"

--- a/python/create_service_diagnostics_bundle.sh
+++ b/python/create_service_diagnostics_bundle.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 readonly SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly DCOS_SERVICE_DIAGNOSTICS_SCRIPT_PATH="dcos-sdk-service-diagnostics/python"
 
-readonly VERSION='v0.6.0'
+readonly VERSION='v0.7.0'
 
 readonly BUNDLES_DIRECTORY="service-diagnostic-bundles"
 readonly DOCKER_IMAGE="mesosphere/dcos-sdk-service-diagnostics:${VERSION}"
@@ -97,7 +97,8 @@ readonly SUPPORTED_DCOS_VERSIONS="
 1.12
 1.13
 1.14
-2.0"
+2.0
+2.1"
 if ! echo "${SUPPORTED_DCOS_VERSIONS}" | grep -qx "${DCOS_CLUSTER_MAJOR_MINOR_VERSION}"; then
   echo "DC/OS ${DCOS_CLUSTER_MAJOR_MINOR_VERSION}.x is not supported by this tool."
   echo "Supported DC/OS versions: ${SUPPORTED_DCOS_VERSIONS}"


### PR DESCRIPTION
Adding support for upcoming DC/OS 2.1 release.

**Note**: I had to set the following before collecting a bundle on a strict cluster:
```
dcos config set core.ssl_verify False
```
Looks related to this update in the [dcos-cli](https://github.com/dcos/dcos-cli/pull/1513) and required the bump from `1.0.1` to `1.1.2`

We should resolve the `core.ssl_verify` matter before releasing this.