### PR TITLE
[DCOS-44747] Add support for Datastax-DSE Diagnostic Bundles.

### DIFF
--- a/python/base_tech_bundle/__init__.py
+++ b/python/base_tech_bundle/__init__.py
@@ -136,6 +136,7 @@ BASE_TECH_BUNDLE = {
     "beta-kafka": KafkaBundle,
     "cassandra": CassandraBundle,
     "confluent-kafka": KafkaBundle,
+    "datastax-dse": CassandraBundle,
     "elastic": ElasticBundle,
     "hdfs": HdfsBundle,
     "kafka": KafkaBundle,


### PR DESCRIPTION
From [this comment](https://github.com/mesosphere/dcos-commons/pull/2735#issuecomment-437440970) by @mpereira, Datastax has different nodeids compared to upstream cassandra.

This PR will add all the requisite work to support Datastax-DSE diagnostic bundles. 