### PR TITLE
Add task reservations endpoint to the diagnostic bundle.

### DIFF
--- a/python/service_bundle.py
+++ b/python/service_bundle.py
@@ -130,7 +130,7 @@ class ServiceBundle(Bundle):
                 response.status_code, response.text
             )
         else:
-            self.write_file("service_v1_debug_taskreservations.json", response.text)
+            self.write_file("service_v1_debug_reservations.json", response.text)
 
     @functools.lru_cache()
     @config.retry

--- a/python/service_bundle.py
+++ b/python/service_bundle.py
@@ -121,7 +121,7 @@ class ServiceBundle(Bundle):
             self.write_file("service_v1_debug_taskStatuses.json", response.text)
 
     @config.retry
-    def create_taskreservations_file(self):
+    def create_reservations_file(self):
         response = sdk_cmd.service_request("GET", self.service_name, "/v1/debug/reservations",
                                            raise_on_error=False)
         if not response.ok:

--- a/python/service_bundle.py
+++ b/python/service_bundle.py
@@ -120,6 +120,18 @@ class ServiceBundle(Bundle):
         else:
             self.write_file("service_v1_debug_taskStatuses.json", response.text)
 
+    @config.retry
+    def create_taskreservations_file(self):
+        response = sdk_cmd.service_request("GET", self.service_name, "/v1/debug/reservations",
+                                           raise_on_error=False)
+        if not response.ok:
+            log.error(
+                "Could not get scheduler task-reservations\nstatus_code: '%s'\nstderr: '%s'",
+                response.status_code, response.text
+            )
+        else:
+            self.write_file("service_v1_debug_taskreservations.json", response.text)
+
     @functools.lru_cache()
     @config.retry
     def configuration_ids(self) -> List[str]:
@@ -186,6 +198,7 @@ class ServiceBundle(Bundle):
         self.create_v2_offers_file()
         self.create_plans_file()
         self.create_taskstatuses_file()
+        self.create_taskreservations_file()
         self.create_configuration_ids_file()
         self.create_configuration_target_id_file()
         self.create_configuration_files()


### PR DESCRIPTION
[SDK v0.57.3](https://github.com/mesosphere/dcos-commons/releases/tag/0.57.3) adds the the `<service>/v1/debug/reservations` endpoint which lists the mesos reservations associated with currently running tasks.

Add reservation endpoint to the service diagnostic bundle here.